### PR TITLE
Fix getLinkHere and initLinkHere for DesiFiberPos

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -2944,8 +2944,6 @@ var ci_radecs = {'CIW':
                   [ 0.0503096,  0.0503096, -0.0488675, -0.0488675]],
                 };
 
-var desiLocationStack = [];
-
 var DesiOverlay = CatalogOverlay.extend({
     ready: function() {
         CatalogOverlay.prototype.ready.call(this);
@@ -2955,21 +2953,12 @@ var DesiOverlay = CatalogOverlay.extend({
             return;
         }
         this._show = true;
-        
-        var latlng;
-        if (desiLocationStack.length > 0) { // If a previous DesiOverlay is being displayed
-            latlng = desiLocationStack[0];  // set latlng to its location
-        } else if (this._got_initial_position) { // If radec is specified by url
-            latlng = L.latLng(dec2lat(this.dec), ra2long_C(this.ra, 180))
+        if (!this._got_initial_position) {
+            this.moveTo(map.getCenter());
         } else {
-            latlng = map.getCenter();
+            this.moveTo(L.latLng(dec2lat(this.dec), ra2long_C(this.ra, 180)));
         }
         this._group.addLayer(this._layer);
-        this.moveTo(latlng);
-        desiLocationStack.push(latlng);
-    },
-    overlayRemoved: function(e) {
-        desiLocationStack.pop();
     },
     load: function() {
     },
@@ -3029,6 +3018,15 @@ var DesiFiberPos = DesiOverlay.extend({
             // Tell worker to initiate calculation
             this._worker.postMessage([r0, d0, clong]);
             this._status && this._status.html('calculating...');
+        }
+    },
+    overlayRemoved: function(e) {
+        if (layerMatchesEvent(this, e)) {
+            if (this._fiberpos) {
+                this._layer.removeLayer(this._fiberpos);
+                this._fiberpos = undefined;
+            }
+            this._show = false;
         }
     },
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -2944,6 +2944,8 @@ var ci_radecs = {'CIW':
                   [ 0.0503096,  0.0503096, -0.0488675, -0.0488675]],
                 };
 
+var desiLocationStack = [];
+
 var DesiOverlay = CatalogOverlay.extend({
     ready: function() {
         CatalogOverlay.prototype.ready.call(this);
@@ -2953,12 +2955,21 @@ var DesiOverlay = CatalogOverlay.extend({
             return;
         }
         this._show = true;
-        if (!this._got_initial_position) {
-            this.moveTo(map.getCenter());
+        
+        var latlng;
+        if (desiLocationStack.length > 0) { // If a previous DesiOverlay is being displayed
+            latlng = desiLocationStack[0];  // set latlng to its location
+        } else if (this._got_initial_position) { // If radec is specified by url
+            latlng = L.latLng(dec2lat(this.dec), ra2long_C(this.ra, 180))
         } else {
-            this.moveTo(L.latLng(dec2lat(this.dec), ra2long_C(this.ra, 180)));
+            latlng = map.getCenter();
         }
         this._group.addLayer(this._layer);
+        this.moveTo(latlng);
+        desiLocationStack.push(latlng);
+    },
+    overlayRemoved: function(e) {
+        desiLocationStack.pop();
     },
     load: function() {
     },
@@ -3018,15 +3029,6 @@ var DesiFiberPos = DesiOverlay.extend({
             // Tell worker to initiate calculation
             this._worker.postMessage([r0, d0, clong]);
             this._status && this._status.html('calculating...');
-        }
-    },
-    overlayRemoved: function(e) {
-        if (layerMatchesEvent(this, e)) {
-            if (this._fiberpos) {
-                this._layer.removeLayer(this._fiberpos);
-                this._fiberpos = undefined;
-            }
-            this._show = false;
         }
     },
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -338,6 +338,7 @@ var CatalogOverlay = L.Evented.extend({
             console.log('BUG line 278');
             return;
         }
+
         // add status span after the layer name span
         var nxt = this._checkbox.next();
         var stat = L.DomUtil.create('span', 'layer-status');
@@ -1372,7 +1373,6 @@ function onMapClick(e) {
 
     for (var i=0,len=overlays.length; i<len; i++) {
         console.log('Overlay ' + overlays[i]._name + ' shown? ' + overlays[i]._show);
-        console.log('   link: ' + overlays[i].getLinkHere());
         if (overlays[i]._show) {
             linkurl += '&' + overlays[i].getLinkHere()
         }
@@ -2947,9 +2947,6 @@ var ci_radecs = {'CIW':
 var DesiOverlay = CatalogOverlay.extend({
     ready: function() {
         CatalogOverlay.prototype.ready.call(this);
-        if (!this._got_initial_position) {
-            this.moveTo(map.getCenter());
-        }
     },
     overlayAdded: function(e) {
         if (!layerMatchesEvent(this, e)) {
@@ -2958,10 +2955,30 @@ var DesiOverlay = CatalogOverlay.extend({
         this._show = true;
         if (!this._got_initial_position) {
             this.moveTo(map.getCenter());
+        } else {
+            this.moveTo(L.latLng(dec2lat(this.dec), ra2long_C(this.ra, 180)));
         }
         this._group.addLayer(this._layer);
     },
     load: function() {
+    },
+    getLinkHere: function() {
+        return this._url_term + '=' + this.ra.toFixed(4) + ',' + this.dec.toFixed(4);
+    },
+    initLinkHere: function(val) {
+        if (val === undefined) {
+            return;
+        }
+        words = val.split(',');
+        if (words.length != 2) {
+            return;
+        }
+        var r = Number.parseFloat(words[0]);
+        var d = Number.parseFloat(words[1]);
+        this.ra = r;
+        this.dec = d;
+        this._show = true;
+        this._got_initial_position = true;
     },
 })
 
@@ -2974,6 +2991,8 @@ var DesiFiberPos = DesiOverlay.extend({
         var clong = c.lng
         var d0 = lat2dec(c.lat);
         var r0 = long2ra(clong);
+        this.ra = r0;
+        this.dec = d0;
 
         if (this._show) {
             // Create worker if worker does not exist
@@ -3105,25 +3124,6 @@ var DesiFootprint = DesiOverlay.extend({
         }
         this._ci.setLatLngs(polys);
         this._ci.redraw();
-    },
-    getLinkHere: function() {
-        return 'desifoot=' + this.ra.toFixed(4) + ',' + this.dec.toFixed(4);
-    },
-    initLinkHere: function(val) {
-        if (val === undefined) {
-            return;
-        }
-        words = val.split(',');
-        if (words.length != 2) {
-            return;
-        }
-        var r = Number.parseFloat(words[0]);
-        var d = Number.parseFloat(words[1]);
-        this.ra = r;
-        this.dec = d;
-        this.moveTo(L.latLng(dec2lat(d), ra2long_C(r, 180)));
-        this._got_initial_position = true;
-        console.log('Set initial position for DESI footprint: ' + r + ', ' + d);
     },
 });
 var desifoot = new DesiFootprint('desi-footprint', 'DESI Footprint', {});


### PR DESCRIPTION
Just realized the Link Here button doesn't work for the Desi Fiber layer so I worked up a quick fix. Also fixed the issue that `moveTo` is being called in both `ready()` and `overlayAdded()`.

@sbailey