### PR TITLE
Make DesiTargetCatalog transparent

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -100,3 +100,9 @@ background: #242424;
 .leaflet-tooltip-right.spectrumTooltip {
   margin-left: 15px;
 }
+
+.leaflet-tooltip {
+    background: transparent;
+    color: white;
+    box-shadow: 0 0px 0px rgba(0,0,0,0);
+}

--- a/static/styles.css
+++ b/static/styles.css
@@ -72,8 +72,7 @@
 }
 
 .leaflet-container {
-//background: #000;
-background: #242424;
+    background: #242424;
 }
 
 .leaflet-control-scale-line {
@@ -81,10 +80,11 @@ background: #242424;
     margin-bottom: 15px;
 }
 
-// hmm, can't get this to work
-//.leaflet-control-attribution {
-//    font-size: 200%;
-//}
+/* hmm, can't get this to work
+.leaflet-control-attribution {
+    font-size: 200%;
+}
+*/
 
 #gotosubmit {
     font-size: 100%;
@@ -93,7 +93,7 @@ background: #242424;
     font-size: 100%;
 }
 
-// https://gis.stackexchange.com/questions/212820/overriding-leaflet-tooltip-style
+/* https://gis.stackexchange.com/questions/212820/overriding-leaflet-tooltip-style */
 .leaflet-tooltip-left.spectrumTooltip {
   margin-left: -15px;
 }

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,102 @@
+#map { height: 100%; width: 100%; padding: 1;}
+
+#thebody { margin:0; }
+
+.info {
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    background: rgba(255,255,255,0.8);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+
+.query {
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    background: rgba(255,255,255,0.8);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+
+.upload {
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    background: rgba(255,255,255,0.8);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+
+.objquery {
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    background: rgba(255,255,255,0.8);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+
+.inbrickccd {
+    padding: 6px 8px;
+    font: 14px/16px Arial, Helvetica, sans-serif;
+    background: white;
+    background: rgba(255,255,255,0.8);
+    box-shadow: 0 0 15px rgba(0,0,0,0.2);
+    border-radius: 5px;
+}
+
+.inbrickccd ul {
+    margin-top: 0pt;
+}
+
+.highccd {
+    color: red;
+}
+.highccd:link {
+    color: red;
+}
+.highccd:visited {
+    color: red;
+}
+
+.highexp {
+    color: red;
+}
+.highexp:link {
+    color: red;
+}
+.highexp:visited {
+    color: red;
+}
+
+.leaflet-container {
+//background: #000;
+background: #242424;
+}
+
+.leaflet-control-scale-line {
+    font-size: 200%;
+    margin-bottom: 15px;
+}
+
+// hmm, can't get this to work
+//.leaflet-control-attribution {
+//    font-size: 200%;
+//}
+
+#gotosubmit {
+    font-size: 100%;
+}
+#gotocancel {
+    font-size: 100%;
+}
+
+// https://gis.stackexchange.com/questions/212820/overriding-leaflet-tooltip-style
+.leaflet-tooltip-left.spectrumTooltip {
+  margin-left: -15px;
+}
+.leaflet-tooltip-right.spectrumTooltip {
+  margin-left: 15px;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
   })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
   ga('create', 'UA-5565065-29', 'auto');
   ga('send', 'pageview');
-</script> 
+</script>
 <link rel="stylesheet" href="{% static "leaflet-1.3.1.css" %}" />
 <script src="{% static "leaflet-src-1.3.1.js" %}"></script>
 {# From https://github.com/mapbox/leaflet-pip #}
@@ -577,8 +577,7 @@ var DesiTargetCatalog = CatalogOverlay.extend({
             } else {
                 var txt = labels[i];
                 if (txt.length > 0) {
-                    circ.bindTooltip(txt, { permanent: true, interactive: true,
-                    opacity: 0.5 });
+                    circ.bindTooltip(txt, { permanent: true, interactive: true });
                 }
             }
     

--- a/templates/index.html
+++ b/templates/index.html
@@ -675,12 +675,14 @@ var DesiTargetCatalog = CatalogOverlay.extend({
             }
 
             var circ = L.circle([lat, lng], rad,
-                                {'color':color, 'fillOpacity':0, 'weight':5});
+                                {'color':color, 'fillOpacity':0,
+                                'weight':5, 'opacity': 0.2});
             if (labels === undefined) {
             } else {
                 var txt = labels[i];
                 if (txt.length > 0) {
-                    circ.bindTooltip(txt, { permanent: true, interactive: true });
+                    circ.bindTooltip(txt, { permanent: true, interactive: true,
+                    opacity: 0.5 });
                 }
             }
     

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,6 +25,7 @@
 {# https://github.com/jdfergason/Leaflet.Ellipse #}
 <script src="{% static "l.ellipse.js" %}"></script>
 <script src="{% static "utils.js" %}"></script>
+<link rel="stylesheet" href="{% static "styles.css" %}" />
 
 {% comment %}
 <script src="{% static "leaflet.draw-0.2.4.js" %}"></script>
@@ -33,111 +34,6 @@
 <link rel="stylesheet" href="{% static "leaflet.measurecontrol-20150626.css" %}" />
 {% endcomment %}
 
- <style type="text/css">
-#map { height: 100%; width: 100%; padding: 1;}
-
-#thebody { margin:0; }
-
-.info {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-}
-
-.query {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-}
-
-.upload {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-}
-
-.objquery {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-}
-
-.inbrickccd {
-    padding: 6px 8px;
-    font: 14px/16px Arial, Helvetica, sans-serif;
-    background: white;
-    background: rgba(255,255,255,0.8);
-    box-shadow: 0 0 15px rgba(0,0,0,0.2);
-    border-radius: 5px;
-}
-
-.inbrickccd ul {
-    margin-top: 0pt;
-}
-
-.highccd {
-    color: red;
-}
-.highccd:link {
-    color: red;
-}
-.highccd:visited {
-    color: red;
-}
-
-.highexp {
-    color: red;
-}
-.highexp:link {
-    color: red;
-}
-.highexp:visited {
-    color: red;
-}
-
-.leaflet-container {
-//background: #000;
-background: #242424;
-}
-
-.leaflet-control-scale-line {
-    font-size: 200%;
-    margin-bottom: 15px;
-}
-
-// hmm, can't get this to work
-//.leaflet-control-attribution {
-//    font-size: 200%;
-//}
-
-#gotosubmit {
-    font-size: 100%;
-}
-#gotocancel {
-    font-size: 100%;
-}
-
-// https://gis.stackexchange.com/questions/212820/overriding-leaflet-tooltip-style
-.leaflet-tooltip-left.spectrumTooltip {
-  margin-left: -15px;
-}
-.leaflet-tooltip-right.spectrumTooltip {
-  margin-left: 15px;
-}
-
-</style>
 
 {% endblock %}
 


### PR DESCRIPTION
<img width="882" alt="Screen Shot 2019-03-29 at 1 30 38 AM" src="https://user-images.githubusercontent.com/18119047/55219557-7500c200-51c2-11e9-9bf3-0d0bbf0513e9.png">
This is a simple fix so that targets don't obstruct other objects/each other too much. Feel free to comment below if you think the transparency level could use some further tweaking.
