### PR TITLE
Add DESI tile ID support

### DIFF
--- a/map/cats.py
+++ b/map/cats.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from functools import lru_cache
 import os
 import fitsio
 
@@ -1139,7 +1140,7 @@ def cat_decals(req, ver, zoom, x, y, tag='decals', docache=True):
     f.close()
     return send_file(cachefn, 'application/json', **sendfile_kwargs)
 
-# TODO: add caching
+@lru_cache(maxsize=1)
 def get_desi_tiles():
     """Returns a dictionary mapping of tileid: (ra, dec) of desi tiles
     """

--- a/map/cats.py
+++ b/map/cats.py
@@ -1158,7 +1158,7 @@ def get_desi_tile_radec(tile_id):
     tileradec = get_desi_tiles()
 
     ra, dec = 0, 0
-    if tileid in tileradec:
+    if tile_id in tileradec:
         ra = tileradec[tile_id][0]
         dec = tileradec[tile_id][1]
     return ra, dec

--- a/map/cats.py
+++ b/map/cats.py
@@ -1153,7 +1153,7 @@ def get_desi_tiles():
 
 def get_desi_tile_radec(tile_id):
     """Accepts a tile_id, returns a tuple of ra, dec
-    Raises a RuntimeException if tile_id is not found
+    Raises a RuntimeError if tile_id is not found
     """
     # Load tile radec
     tileradec = get_desi_tiles()

--- a/map/cats.py
+++ b/map/cats.py
@@ -1150,6 +1150,19 @@ def get_desi_tiles():
         tileradec[tileid] = (ra,dec)
     return tileradec
 
+def get_desi_tile_radec(tile_id):
+    """Accepts a tile_id, returns a tuple of ra, dec
+    If tile is not found, return (0, 0)
+    """
+    # Load tile radec
+    tileradec = get_desi_tiles()
+
+    ra, dec = 0, 0
+    if tileid in tileradec:
+        ra = tileradec[tile_id][0]
+        dec = tileradec[tile_id][1]
+    return ra, dec
+
 def _get_decals_cat(wcs, tag='decals'):
     from astrometry.util.fits import fits_table, merge_tables
     from map.views import get_survey

--- a/map/cats.py
+++ b/map/cats.py
@@ -18,7 +18,9 @@ except:
     # django 2.0
     from django.urls import reverse
 from map.utils import send_file, trymakedirs, get_tile_wcs, oneyear
-
+from astropy.table import Table
+# I am a little hesistant to introduce another dependency here.
+# Any better ideas? -- Mark Zhang (April 3 2019)
 
 debug = print
 if not settings.DEBUG_LOGGING:
@@ -54,6 +56,7 @@ catversions = {
     'sdss-cat': [1,],
     'phat-clusters': [1,],
     'ps1': [1,],
+    'desi-tiles': [1,],
 }
 
 test_cats = []
@@ -1135,6 +1138,17 @@ def cat_decals(req, ver, zoom, x, y, tag='decals', docache=True):
     f.write(json)
     f.close()
     return send_file(cachefn, 'application/json', **sendfile_kwargs)
+
+# TODO: add caching
+def get_desi_tiles():
+    """Returns a dictionary mapping of tileid: (ra, dec) of desi tiles
+    """
+    path = os.path.join(settings.DATA_DIR, 'desi-tiles.fits')
+    t = Table.read(path)
+    tileradec = dict()
+    for tileid, ra, dec in t['TILEID', 'RA', 'DEC']:
+        tileradec[tileid] = (ra,dec)
+    return tileradec
 
 def _get_decals_cat(wcs, tag='decals'):
     from astrometry.util.fits import fits_table, merge_tables

--- a/map/cats.py
+++ b/map/cats.py
@@ -20,8 +20,6 @@ except:
     from django.urls import reverse
 from map.utils import send_file, trymakedirs, get_tile_wcs, oneyear
 from astropy.table import Table
-# I am a little hesistant to introduce another dependency here.
-# Any better ideas? -- Mark Zhang (April 3 2019)
 
 debug = print
 if not settings.DEBUG_LOGGING:

--- a/map/cats.py
+++ b/map/cats.py
@@ -19,7 +19,6 @@ except:
     # django 2.0
     from django.urls import reverse
 from map.utils import send_file, trymakedirs, get_tile_wcs, oneyear
-from astropy.table import Table
 
 debug = print
 if not settings.DEBUG_LOGGING:
@@ -1142,10 +1141,12 @@ def cat_decals(req, ver, zoom, x, y, tag='decals', docache=True):
 def get_desi_tiles():
     """Returns a dictionary mapping of tileid: (ra, dec) of desi tiles
     """
+    from astrometry.util.fits import fits_table
+
     path = os.path.join(settings.DATA_DIR, 'desi-tiles.fits')
-    t = Table.read(path)
+    t = fits_table(path)
     tileradec = dict()
-    for tileid, ra, dec in t['TILEID', 'RA', 'DEC']:
+    for tileid, ra, dec in zip(t.tileid, t.ra, t.dec):
         tileradec[tileid] = (ra,dec)
     return tileradec
 

--- a/map/cats.py
+++ b/map/cats.py
@@ -1152,16 +1152,17 @@ def get_desi_tiles():
 
 def get_desi_tile_radec(tile_id):
     """Accepts a tile_id, returns a tuple of ra, dec
-    If tile is not found, return (0, 0)
+    Raises a RuntimeException if tile_id is not found
     """
     # Load tile radec
     tileradec = get_desi_tiles()
 
-    ra, dec = 0, 0
     if tile_id in tileradec:
         ra = tileradec[tile_id][0]
         dec = tileradec[tile_id][1]
-    return ra, dec
+        return ra, dec
+    else:
+        raise RuntimeError("DESI tile not found")
 
 def _get_decals_cat(wcs, tag='decals'):
     from astrometry.util.fits import fits_table, merge_tables

--- a/map/urls.py
+++ b/map/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.urls import path
 
 from map import views
 from map import cats
@@ -312,6 +313,9 @@ urlpatterns = [
 
     # PHAT version of the viewer.
     url(r'^phat/?$', views.phat),
+
+    # DESI tile id
+    path('desitile/<int:tile_id>', views.desi_tile, name='desi_tile'),
 
     # fall-through
     url(r'', views.index),

--- a/map/urls.py
+++ b/map/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-from django.urls import path
 
 from map import views
 from map import cats
@@ -313,9 +312,6 @@ urlpatterns = [
 
     # PHAT version of the viewer.
     url(r'^phat/?$', views.phat),
-
-    # DESI tile id
-    path('desitile/<int:tile_id>', views.desi_tile, name='desi_tile'),
 
     # fall-through
     url(r'', views.index),

--- a/map/views.py
+++ b/map/views.py
@@ -275,8 +275,8 @@ def _index(req,
 
     # Process desi_tile parameter
     try:
-        # Set ra and dec
         tileid = req.GET.get('desi_tile')
+        # Set ra and dec
         ra, dec = get_desi_tile_radec(int(tileid))
     except:
         pass

--- a/map/views.py
+++ b/map/views.py
@@ -31,7 +31,7 @@ from viewer import settings
 from map.utils import (get_tile_wcs, trymakedirs, save_jpeg, ra2long, ra2long_B,
                        send_file, oneyear)
 from map.coadds import get_scaled
-from map.cats import get_random_galaxy, get_desi_tiles
+from map.cats import get_random_galaxy, get_desi_tile_radec
 
 import matplotlib
 matplotlib.use('Agg')
@@ -275,14 +275,9 @@ def _index(req,
 
     # desi_tile parameter
     try:
-        # Load tile radec
-        tileradec = get_desi_tiles
-
         # Set ra and dec
         tileid = req.GET.get('desi_tile')
-        if tileid in tileradec:
-            ra = tileradec[tileid][0]
-            dec = tileradec[tileid][1]
+        ra, dec = get_desi_tile_radec(tileid)
     except:
         pass
 

--- a/map/views.py
+++ b/map/views.py
@@ -26,7 +26,6 @@ except:
     from django.urls import reverse
 
 from django import forms
-from django.shortcuts import redirect
 from viewer import settings
 from map.utils import (get_tile_wcs, trymakedirs, save_jpeg, ra2long, ra2long_B,
                        send_file, oneyear)

--- a/map/views.py
+++ b/map/views.py
@@ -548,20 +548,9 @@ def name_query(req):
         return HttpResponse(json.dumps(dict(ra=ra, dec=dec, name=name)),
                             content_type='application/json')
 
+    # Check for RA,Dec in decimal degrees or H:M:S.
     words = obj.strip().split()
     print('Parsing name query: words', words)
-
-    # Checks if query is desi tile
-    if words[0] == "DESI":
-        try:
-            tileid = int(words[1])
-            ra, dec = get_desi_tile_radec(tileid)
-            return HttpResponse(json.dumps(dict(ra=ra, dec=dec, name=obj)),
-                                content_type='application/json')
-        except:
-            pass
-
-    # Check for RA,Dec in decimal degrees or H:M:S.
     if len(words) == 2:
         try:
             rastr,decstr = words

--- a/map/views.py
+++ b/map/views.py
@@ -277,7 +277,7 @@ def _index(req,
     try:
         # Set ra and dec
         tileid = req.GET.get('desi_tile')
-        ra, dec = get_desi_tile_radec(tileid)
+        ra, dec = get_desi_tile_radec(int(tileid))
     except:
         pass
 

--- a/map/views.py
+++ b/map/views.py
@@ -273,7 +273,7 @@ def _index(req,
     except:
         pass
 
-    # desi_tile parameter
+    # Process desi_tile parameter
     try:
         # Set ra and dec
         tileid = req.GET.get('desi_tile')
@@ -548,9 +548,20 @@ def name_query(req):
         return HttpResponse(json.dumps(dict(ra=ra, dec=dec, name=name)),
                             content_type='application/json')
 
-    # Check for RA,Dec in decimal degrees or H:M:S.
     words = obj.strip().split()
     print('Parsing name query: words', words)
+
+    # Checks if query is desi tile
+    if words[0] == "DESI":
+        try:
+            tileid = int(words[1])
+            ra, dec = get_desi_tile_radec(tileid)
+            return HttpResponse(json.dumps(dict(ra=ra, dec=dec, name=obj)),
+                                content_type='application/json')
+        except:
+            pass
+
+    # Check for RA,Dec in decimal degrees or H:M:S.
     if len(words) == 2:
         try:
             rastr,decstr = words

--- a/map/views.py
+++ b/map/views.py
@@ -274,6 +274,24 @@ def _index(req,
     except:
         pass
 
+    # desi_tile parameter
+    try:
+        # Load tile radec
+        # TODO: move this to a separate function and add caching
+        path = os.path.join(settings.DATA_DIR, 'desi-tiles.fits')
+        t = Table.read(path)
+        tileradec = dict()
+        for tileid, ra, dec in t['TILEID', 'RA', 'DEC']:
+            tileradec[tileid] = (ra,dec)
+
+        # Set ra and dec
+        tileid = req.GET.get('desi_tile')
+        if tileid in tileradec:
+            ra = tileradec[tileid][0]
+            dec = tileradec[tileid][1]
+    except:
+        pass
+
     galname = None
     if ra is None or dec is None:
         ra,dec,galname = get_random_galaxy(layer=layer)
@@ -5245,29 +5263,6 @@ def ra_ranges_overlap(ralo, rahi, ra1, ra2):
     #print('3:', cw31, cw32)
     #print('4:', cw41, cw42)
     return np.logical_and(cw32 <= 0, cw41 >= 0)
-
-def desi_tile(request, **kwargs):
-    # Load tile radec
-    # TODO: move this to a separate function and add caching
-    path = os.path.join(settings.DATA_DIR, 'desi-tiles.fits')
-    t = Table.read(path)
-    tileradec = dict()
-    for tileid, ra, dec in t['TILEID', 'RA', 'DEC']:
-        tileradec[tileid] = (ra,dec)
-
-    # Construct url
-    query = request.GET.copy()
-    tileId = kwargs['tile_id']
-    if tileid in tileradec:
-        # Add radec values to QueryDict
-        query['ra'] = tileradec[tileid][0]
-        query['dec'] = tileradec[tileid][1]
-        
-        # Construct a radec string for desifoot and desifiber layers
-        radec = str(query['ra']) + ',' + str(query['dec'])
-        query['desifoot'] = radec
-        query['desifiber'] = radec
-    return redirect('/?'+query.urlencode())
 
 if __name__ == '__main__':
     import sys

--- a/map/views.py
+++ b/map/views.py
@@ -31,8 +31,7 @@ from viewer import settings
 from map.utils import (get_tile_wcs, trymakedirs, save_jpeg, ra2long, ra2long_B,
                        send_file, oneyear)
 from map.coadds import get_scaled
-from map.cats import get_random_galaxy
-from astropy.table import Table
+from map.cats import get_random_galaxy, get_desi_tiles
 
 import matplotlib
 matplotlib.use('Agg')
@@ -277,12 +276,7 @@ def _index(req,
     # desi_tile parameter
     try:
         # Load tile radec
-        # TODO: move this to a separate function and add caching
-        path = os.path.join(settings.DATA_DIR, 'desi-tiles.fits')
-        t = Table.read(path)
-        tileradec = dict()
-        for tileid, ra, dec in t['TILEID', 'RA', 'DEC']:
-            tileradec[tileid] = (ra,dec)
+        tileradec = get_desi_tiles
 
         # Set ra and dec
         tileid = req.GET.get('desi_tile')

--- a/templates/index.html
+++ b/templates/index.html
@@ -2099,7 +2099,8 @@ $(document).ready(function() {
                                        window.location.pathname +
                                        "?desi_tile=" + splited[1] +
                                        '&layer=' + layer_name +
-                                       '&desifoot&desifiber';
+                                       '&desifoot&desifiber' +
+                                       '&zoom=8';
                 return;
             }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -2098,7 +2098,8 @@ $(document).ready(function() {
                 window.location.href = window.location.origin +
                                        window.location.pathname +
                                        "?desi_tile=" + splited[1] +
-                                       '&layer=' + layer_name;
+                                       '&layer=' + layer_name +
+                                       '&desifoot&desifiber';
                 return;
             }
 
@@ -2992,7 +2993,8 @@ var DesiOverlay = CatalogOverlay.extend({
         return this._url_term + '=' + this.ra.toFixed(4) + ',' + this.dec.toFixed(4);
     },
     initLinkHere: function(val) {
-        if (val === undefined) {
+        if (typeof val !== String) {
+            this._show = true;
             return;
         }
         words = val.split(',');
@@ -3156,8 +3158,8 @@ var DesiFootprint = DesiOverlay.extend({
 var desifoot = new DesiFootprint('desi-footprint', 'DESI Footprint', {});
 desifoot._url_term = 'desifoot';
 var desifiber = new DesiFiberPos('desi-fiberpos', 'DESI Fibers', {});
-desifiber._url_term = 'desifiber'
-
+desifiber._url_term = 'desifiber';
+// TODO: Make url terms a constant
 
 var overlays = [
     {% if enable_phat %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2091,6 +2091,17 @@ $(document).ready(function() {
         // when Enter is hit in the Object name search box
         if (event.keyCode == 13) {
             var qstring = $('#objquery').val();
+            
+            // Check if query is on desi tile
+            var splited = qstring.split(" ");
+            if (splited.length == 2 && splited[0] === "DESI") {
+                window.location.href = window.location.origin +
+                                       window.location.pathname +
+                                       "?desi_tile=" + splited[1] +
+                                       '&layer=' + layer_name;
+                return;
+            }
+
             var url = L.Util.template(name_query_url, L.extend({
                 obj: qstring,
             }));


### PR DESCRIPTION
Automatically jump to a location given DESI tile ID.

Usage:
1. Using url query parameters. (e.g. http://127.0.0.1:8000/?desi_tile=1000)
2. Using Jump To Object text box located on the lower left. (e.g. type in DESI 1000 and hit enter). Redirects the user to the corresponding location and automatically turns on DESI Footprint and Fiber layers.

A few lingering questions:
1. Data file is current committed to git (in data/desi-tiles.fits). I noticed no data files in this directory exist in git before, so maybe I should remove it?
2. I put the query functions `get_desi_tile_radec` and `get_desi_tiles` in map/cats.py. Is this appropriate?
3. Right now every time `get_desi_tiles` gets called the server reads a 2.1 MB file from the disk. Should I introduce a caching mechanism?

Thanks!