### PR TITLE
Fix DESI target id discrepancy

### DIFF
--- a/map/cats.py
+++ b/map/cats.py
@@ -743,6 +743,10 @@ def cat_targets_drAB(req, ver, cats=[], tag='', bgs=False, sky=False, bright=Fal
         rtn.update(color=colors)
     if nobs is not None:
         rtn.update(nobs=nobs)
+    
+    # Convert targetid to string to prevent rounding errors
+    rtn['targetid'] = [str(s) for s in rtn['targetid']]
+    
     return HttpResponse(json.dumps(rtn), content_type='application/json')
 
 def cat_lslga(req, ver):


### PR DESCRIPTION
I noticed target ids would arrive at the browser with one or two bits off from what is seen in the backend.

As an example, if you a user accesses the url http://legacysurvey.org/viewer-dev?ra=178.1051&dec=20.6939&zoom=16&layer=decals-dr7&targets-dr67

The backend sees the ids as:
<img width="816" alt="Screen Shot 2019-04-10 at 11 12 45 PM" src="https://user-images.githubusercontent.com/18119047/55934667-2f8ebc80-5be6-11e9-8a77-2d7dadc5ed6f.png">

The frontend sees the ids as:
<img width="972" alt="Screen Shot 2019-04-10 at 11 11 37 PM" src="https://user-images.githubusercontent.com/18119047/55934673-33bada00-5be6-11e9-9e34-83e58bb0a0f3.png">

I think this is caused by floating point imprecision, because this error does not occur if I set the id to some small number (say, 10), but I am not sure where the numbers got converted to floating point numbers. The fix is rather simple: convert the targetids to string before transmitting. That being said, any input on this is greatly appreciated!