### PR TITLE
Fix catalog link color

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -106,3 +106,7 @@
     color: white;
     box-shadow: 0 0px 0px rgba(0,0,0,0);
 }
+
+.leaflet-tooltip a {
+    color: white;
+}


### PR DESCRIPTION
No style was specified for links within leaflet-tooltip (i.e. catalog labels), while the default blue has very limited visibility on a black background.
This commit changes link color to white.