### PR TITLE
Fix LSLGA galaxy centering in jpeg cutout images

### DIFF
--- a/map/views.py
+++ b/map/views.py
@@ -1310,7 +1310,7 @@ class MapLayer(object):
             from map.cats import query_lslga_radecbox
             galaxies = query_lslga_radecbox(ralo, rahi, declo, dechi)
 
-            for r in galaxies:
+            for r in galaxies if galaxies is not None else []:
 
                 RA, DEC = r.ra, r.dec
                 RAD = r.radius_arcsec

--- a/map/views.py
+++ b/map/views.py
@@ -1298,8 +1298,9 @@ class MapLayer(object):
             from PIL import Image, ImageDraw
             img = Image.open(tilefn)
 
-            ra, dec = wcs.crval
-            img_cx, img_cy = wcs.crpix
+            ra, dec = wcs.radec_center()
+            img_cx = img.size[0] / 2
+            img_cy = img.size[1] / 2
             pixscale = wcs.pixel_scale()
 
             ralo = ra - (img_cx * pixscale / 3600 / np.cos(np.deg2rad(dec)))
@@ -1338,13 +1339,14 @@ class MapLayer(object):
                 rotated = overlay.rotate(PA, expand=True)
                 rotated_width, rotated_height = rotated.size
 
-                ellipse_x = img_cx - ((RA - ra) * 3600 / pixscale * np.cos(np.deg2rad(dec)))
-                ellipse_y = img_cy - ((DEC - dec) * 3600 / pixscale)
+                ok, ellipse_x, ellipse_y = wcs.radec2pixelxy(RA, DEC)
 
-                paste_shift_x = int(ellipse_x - rotated_width / 2)
-                paste_shift_y = int(ellipse_y - rotated_height / 2)
+                if ok:
 
-                img.paste(rotated, (paste_shift_x, paste_shift_y), rotated)
+                    paste_shift_x = int(ellipse_x - rotated_width / 2)
+                    paste_shift_y = int(ellipse_y - rotated_height / 2)
+
+                    img.paste(rotated, (paste_shift_x, paste_shift_y), rotated)
 
             img.save(tilefn)
     

--- a/map/views.py
+++ b/map/views.py
@@ -1327,7 +1327,8 @@ class MapLayer(object):
                 draw = ImageDraw.ImageDraw(overlay)
                 box_corners = (0, 0, overlay_width, overlay_height)
                 ellipse_color = '#' + req.GET.get('lslgacolor', '#3388ff').lstrip('#')
-                draw.ellipse(box_corners, fill=None, outline=ellipse_color, width=3)
+                ellipse_width = int(np.round(float(req.GET.get('lslgawidth', 3)), 0))
+                draw.ellipse(box_corners, fill=None, outline=ellipse_color, width=ellipse_width)
 
                 rotated = overlay.rotate(PA, expand=True)
                 rotated_width, rotated_height = rotated.size

--- a/map/views.py
+++ b/map/views.py
@@ -1317,6 +1317,11 @@ class MapLayer(object):
                 AB = r.ba
                 PA = r.pa
 
+                if np.isnan(AB):
+                    AB = 1
+                if np.isnan(PA):
+                    PA = 90
+
                 major_axis_arcsec = RAD * 2
                 minor_axis_arcsec = major_axis_arcsec * AB
 

--- a/map/views.py
+++ b/map/views.py
@@ -1332,7 +1332,7 @@ class MapLayer(object):
                 rotated = overlay.rotate(PA, expand=True)
                 rotated_width, rotated_height = rotated.size
 
-                ellipse_x = img_cx - ((RA - ra) * 3600 / pixscale))
+                ellipse_x = img_cx - ((RA - ra) * 3600 / pixscale * np.cos(np.deg2rad(dec)))
                 ellipse_y = img_cy - ((DEC - dec) * 3600 / pixscale)
 
                 paste_shift_x = int(ellipse_x - rotated_width / 2)

--- a/map/views.py
+++ b/map/views.py
@@ -1299,14 +1299,13 @@ class MapLayer(object):
             img = Image.open(tilefn)
 
             ra, dec = wcs.crval
+            img_cx, img_cy = wcs.crpix
             pixscale = wcs.pixel_scale()
 
-            width, height = img.size
-
-            ralo = ra - ((width / 2) * pixscale / 3600 / np.cos(np.deg2rad(dec)))
-            rahi = ra + ((width / 2) * pixscale / 3600 / np.cos(np.deg2rad(dec)))
-            declo = dec - ((height / 2) * pixscale / 3600)
-            dechi = dec + ((height / 2) * pixscale / 3600)
+            ralo = ra - (img_cx * pixscale / 3600 / np.cos(np.deg2rad(dec)))
+            rahi = ra + (img_cx * pixscale / 3600 / np.cos(np.deg2rad(dec)))
+            declo = dec - (img_cy * pixscale / 3600)
+            dechi = dec + (img_cy * pixscale / 3600)
 
             from map.cats import query_lslga_radecbox
             galaxies = query_lslga_radecbox(ralo, rahi, declo, dechi)
@@ -1333,11 +1332,11 @@ class MapLayer(object):
                 rotated = overlay.rotate(PA, expand=True)
                 rotated_width, rotated_height = rotated.size
 
-                pix_from_left = (rahi - RA) * 3600 / pixscale
-                pix_from_top = (dechi - DEC) * 3600 / pixscale
+                ellipse_x = img_cx - ((RA - ra) * 3600 / pixscale))
+                ellipse_y = img_cy - ((DEC - dec) * 3600 / pixscale)
 
-                paste_shift_x = int(pix_from_left - rotated_width / 2)
-                paste_shift_y = int(pix_from_top - rotated_height / 2)
+                paste_shift_x = int(ellipse_x - rotated_width / 2)
+                paste_shift_y = int(ellipse_y - rotated_height / 2)
 
                 img.paste(rotated, (paste_shift_x, paste_shift_y), rotated)
 


### PR DESCRIPTION
Apply `np.cos(np.deg2rad(dec))` correction when converting galaxy RA to pixel x-coordinate to fix issue where galaxy ellipses were drawn off-center from the galaxies (example <http://legacysurvey.org/viewer-dev/jpeg-cutout?ra=252.135&dec=35.525&zoom=13&layer=decals-dr7&lslga&width=500&height=500>). Additionally, add a URL argument to specify the width of the ellipse (default 3px), and handle the case where the `lslga` URL argument is passed but there are no LSLGA galaxies in the frame.