### PR TITLE
Fix dict membership check in LSLGA ellipse drawing

### DIFF
--- a/map/views.py
+++ b/map/views.py
@@ -1293,7 +1293,7 @@ class MapLayer(object):
         if get_images:
             return rimgs
 
-        if "lslga" in req.GET:
+        if "lslga" in req.GET or "lslga-model" in req.GET:
 
             from PIL import Image, ImageDraw
             img = Image.open(tilefn)

--- a/map/views.py
+++ b/map/views.py
@@ -1322,11 +1322,11 @@ class MapLayer(object):
             for r in galaxies if galaxies is not None else []:
 
                 RA, DEC = r.ra, r.dec
-                if req.GET == 'lslga':
+                if req.GET.get('lslga', None) == '':
                     RAD = r.radius_arcsec
                     AB = r.ba
                     PA = r.pa
-                elif req.GET == 'lslga-model':
+                elif req.GET.get('lslga-model', None) == '':
                     RAD = r.radius_model_arcsec
                     AB = r.ba_model
                     PA = r.pa_model


### PR DESCRIPTION
Fix a second instance where checking for membership of the `lslga` and `lslga-model` options in the request URL options dict should use the `get` method instead of checking for equality with the dict.

Also, run the ellipse overlay code if either the `lslga` or `lslga-model` options are in the request.